### PR TITLE
updates to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ kramdown:
   input: GFM
   hard_wrap: false
   parse_block_html: true
-
 url: http://thehackerwithin.github.com/illinois
 name: Hacker Within
 chapter: Illinois

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,12 @@
-markdown: rdiscount
 highlighter: pygments
 permalink: /posts/:title
-rdiscount:
-  extensions: [smart]
+future: true
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+  parse_block_html: true
+
 url: http://thehackerwithin.github.com/illinois
 name: Hacker Within
 chapter: Illinois


### PR DESCRIPTION
Hi folks, I recently learned that GitHub is dropping support for rdiscount. Our current setup will look hideous as soon as that switch is flipped. This PR fixes it by relying on the GitHub-preferred kramdown.

See also:
https://github.com/holman/left/issues/43
https://github.com/github/pages-gem/issues/179